### PR TITLE
Add ability to populate extra data from the principal to UserInterface

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ grails:
                 id: 'id'
                 email: 'emailAddress'
                 username: 'login'
+                data: # Additional properties to be retrieved from user details object and passed as extra properties to Sentry user interface.
+                    - 'authorities'
             priorities: 
                 HIGH: [java.lang, com.microsoft.sqlserver.jdbc.SQLServerException]
                 MID: [com.company.exception]

--- a/src/main/groovy/grails/plugin/sentry/SentryConfig.groovy
+++ b/src/main/groovy/grails/plugin/sentry/SentryConfig.groovy
@@ -89,7 +89,8 @@ class SentryConfig {
             springSecurityUserProperties = new SpringSecurityUserProperties(
                     id: (config.springSecurityUserProperties as Map).id?.toString() ?: null,
                     email: (config.springSecurityUserProperties as Map).email?.toString() ?: null,
-                    username: (config.springSecurityUserProperties as Map).username?.toString() ?: null
+                    username: (config.springSecurityUserProperties as Map).username?.toString() ?: null,
+                    data: (config.springSecurityUserProperties as Map).data as List ?: null
             )
         }
     }
@@ -115,6 +116,7 @@ class SentryConfig {
         String id
         String email
         String username
+        List data
     }
 
 }

--- a/src/main/groovy/grails/plugin/sentry/SpringSecurityUserEventBuilderHelper.groovy
+++ b/src/main/groovy/grails/plugin/sentry/SpringSecurityUserEventBuilderHelper.groovy
@@ -55,6 +55,7 @@ class SpringSecurityUserEventBuilderHelper implements EventBuilderHelper {
                 String idPropertyName = 'id'
                 String emailPropertyName = null
                 String usernamePropertyName = 'username'
+                List data = null
 
                 if (sentryConfig?.springSecurityUserProperties &&
                         sentryConfig?.springSecurityUserProperties instanceof Map) {
@@ -70,13 +71,21 @@ class SpringSecurityUserEventBuilderHelper implements EventBuilderHelper {
                             sentryConfig.springSecurityUserProperties.username instanceof String) {
                         usernamePropertyName = sentryConfig.springSecurityUserProperties.username
                     }
+                    if (sentryConfig.springSecurityUserProperties.data &&
+                            sentryConfig.springSecurityUserProperties.data instanceof List) {
+                        data = sentryConfig.springSecurityUserProperties.data
+                    }
                 }
 
                 def id = principal[idPropertyName].toString()
                 String username = principal[usernamePropertyName].toString()
                 String ipAddress = getIpAddress(sentryServletRequestListener?.getServletRequest())
                 String email = emailPropertyName ? principal[emailPropertyName].toString() : null
-                UserInterface userInterface = new UserInterface(id, username, ipAddress, email)
+                Map<String, Object> extraData = [:]
+                data.each { String key ->
+                    extraData[key] = principal[key].toString()
+                }
+                UserInterface userInterface = new UserInterface(id, username, ipAddress, email, extraData)
                 eventBuilder.withSentryInterface(userInterface, true)
             }
         }


### PR DESCRIPTION
Noticed there is now an extra data field that can be populated on `UserInterface` - useful for logging extra things stored on the principal - such as tenantId's, etc