### PR TITLE
Fixed boolean config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ plugins {
     id 'com.jfrog.artifactory' version '4.4.0'
 }
 
-version "1${sentryLogbackVersion}"
+version "1${sentryLogbackVersion}.1"
 group 'org.grails.plugins'
 
 apply plugin: 'eclipse'

--- a/src/main/groovy/grails/plugin/sentry/SentryConfig.groovy
+++ b/src/main/groovy/grails/plugin/sentry/SentryConfig.groovy
@@ -43,7 +43,7 @@ class SentryConfig {
             active = true
         }
 
-        if (config.containsKey('active') && config.active == false) {
+        if (config.containsKey('active') && config.active as String == 'false') {
             active = false
         }
 
@@ -72,16 +72,16 @@ class SentryConfig {
             tags = config.tags as Map<String, String>
         }
 
-        if (config.logClassName == true) {
+        if (config.logClassName as String == 'true') {
             logClassName = true
         }
-        if (config.logHttpRequest == true) {
+        if (config.logHttpRequest as String == 'true') {
             logHttpRequest = true
         }
-        if (config.disableMDCInsertingServletFilter == true) {
+        if (config.disableMDCInsertingServletFilter as String == 'true') {
             disableMDCInsertingServletFilter = true
         }
-        if (config.springSecurityUser == true) {
+        if (config.springSecurityUser as String == 'true') {
             springSecurityUser = true
         }
 


### PR DESCRIPTION
Hi!

It's a small fix. Only for apps which use yaml as a config. Sometimes after parsing yaml some values will be transformed to String instead of Boolean. In this case, SentryConfig doesn't work correctly. This fix just compares all values as a String.